### PR TITLE
🔥 Add missing GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of our GitHub Certifications program to help with college applications.",
+        "schedule": "Tuesdays and Thursdays, 3:00 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## 🚨 Urgent: Add Missing GitHub Skills Activity

This PR addresses **Issue #6** - the time-sensitive missing GitHub Skills activity that was announced by the principal.

### 📝 Changes Made
- ✅ Added "GitHub Skills" to the extracurricular activities list
- ✅ Includes proper description mentioning GitHub Certifications program
- ✅ Set up schedule: Tuesdays and Thursdays, 3:00 PM - 4:30 PM  
- ✅ Capacity for 25 students (anticipating high interest)
- ✅ Ready for immediate student registration

### 🎯 Problem Solved
As mentioned by Hewbie C. (11th Grade Student), the principal announced this new GitHub partnership in the school assembly, but the activity was missing from the signup system. **Registration deadline is this week**, so this fix is urgent.

### 🏆 Benefits
- Students can now register for the GitHub Skills program
- Supports the GitHub Certifications program for college applications
- Addresses the time-sensitive registration deadline
- Enhances our technology curriculum offerings

### ✅ Testing
- [x] Verified activity appears in activities list
- [x] Confirmed all required fields are present
- [x] Tested API endpoint returns new activity
- [x] Application runs without errors

**Ready for immediate merge** to meet the registration deadline! 🚀

Fixes #6